### PR TITLE
Fix file read/write encoding and bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 metadata.json
 example_config.json
+*.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,9 @@
 {
-    "python.formatting.provider": "black",
     "[python]": {
         "editor.formatOnSave": true,
+        "editor.defaultFormatter": "ms-python.black-formatter",
     },
     "editor.rulers": [88],
-
-    // Enable relevant linters
-    "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true,
 
     // --no-cov needed so that breakpoints work: https://github.com/microsoft/vscode-python/issues/693
     "python.testing.pytestArgs": ["--no-cov"],

--- a/epi_downloader.py
+++ b/epi_downloader.py
@@ -65,7 +65,7 @@ class CacheClient:
         # If the data has already been cached (and the user hasn't opted out of using
         # the cache) then load it from disk
         if not self._ignore_cache and file_path.exists():
-            with file_path.open() as file:
+            with file_path.open(encoding="utf-8") as file:
                 return file.read()
 
         # Make HTTP request
@@ -73,7 +73,7 @@ class CacheClient:
         response.raise_for_status()
 
         # Cache data on disk
-        with file_path.open("w") as file:
+        with file_path.open("w", encoding="utf-8") as file:
             file.write(response.text)
 
         return response.text
@@ -146,7 +146,7 @@ async def load_all_model_versions(
 
 def load_config(config_path: str, metadata: Metadata) -> Config:
     """Load the config file from disk."""
-    with open(config_path) as file:
+    with open(config_path, encoding="utf-8") as file:
         config = json.load(file)
 
     out: Config = {}
@@ -294,7 +294,7 @@ def parse_metadata(metadata: dict[str, Any]) -> Metadata:
 def write_json(file_name: str, data: Any) -> None:
     """Save the specified data to disk in JSON format."""
     print(f"Saving {file_name}")
-    with open(file_name, "w") as file:
+    with open(file_name, "w", encoding="utf-8") as file:
         json.dump(data, file, indent=4)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "EPI downloader"
-version = "0.1.0"
-description = ""
+version = "0.2.0"
+description = "A tool for downloading data from the Epi Visualisation website."
 authors = ["Alex Dewar <a.dewar@imperial.ac.uk>"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
It turns out the default file encoding used by Python for both reading and writing files is platform dependent, meaning if you're trying to save UTF8-encoded data on Windows it's likely to fail, as the default encoding is Windows 1252(!). This is *horrid*, but you can fix it by adding `encoding="utf-8"` to any calls to `open()`.

Bump the project version so I can issue a new release.